### PR TITLE
chore: improving project configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
         "build-master": "rm -rf ./master/build && tsc -p ./master",
         "build-local": "rm -rf ./local/build && tsc -p ./local",
         "lint": "eslint . --ext .ts",
+        "fix": "eslint . --ext .ts --fix",
         "update": "npm i --if-present && npm i --prefix local --if-present && npm i --prefix master --if-present"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.8",
         "@typescript-eslint/parser": "^5.59.8",
-        "eslint": "^8.42.0"
+        "eslint": "^8.42.0",
+        "typescript": "^5.1.0"
     }
 }


### PR DESCRIPTION
The most important part of this change is for all developers to use the same TS version, instead of whatever older or newer version they have installed globally (`npm i -g typescript`).
This can save you some headaches down the line, when more and more people start adding code to the project.

The other change is the `npm run fix` command, which simply tells ESlint to automatically fix whatever issues it can fix.
If you like that command, I could also help you set up a `pre-commit` husky hook that auto-fixes eslint issues and fails the commit if there are any error-level issues that couldn't be fixed.
By the way - the same type of pre-commit hooks can also be used to run test-automation (when it gets written). It will make commits a lot slower, but it would force people to check their test results.

So... should I add the git husky hooks as well?