### PR TITLE
fix: Change dotenv import to specifically use config to avoid compile…

### DIFF
--- a/local/src/common/logging.ts
+++ b/local/src/common/logging.ts
@@ -1,5 +1,5 @@
-import dotenv from "dotenv";
-dotenv.config({path: "./local/.env"});
+import {config} from "dotenv";
+config({path: "./local/.env"});
 
 export let verboseEnabled = process.env.VERBOSE === "true"; 
 

--- a/local/src/discord/main.ts
+++ b/local/src/discord/main.ts
@@ -3,9 +3,9 @@ import type { Interaction, Message } from "discord.js";
 import { IntentsBitField } from "discord.js";
 import { Client } from "discordx";
 
-import dotenv from "dotenv";
+import {config} from "dotenv";
 
-dotenv.config();
+config();
 
 export const bot = new Client({
     // To use only guild command

--- a/local/src/index.ts
+++ b/local/src/index.ts
@@ -1,11 +1,11 @@
-import dotenv from "dotenv";
+import {config} from "dotenv";
 //import { startDiscordServer } from "./discord/client";
 import {startDiscordServer} from "./discord/main";
 import {runClient} from "./client/main";
 
 console.log("--- MegaAntiCheat Local Client ---");
 
-dotenv.config({path: "./local/.env"});
+config({path: "./local/.env"});
 
 export const headlessMode = process.env.HEADLESS === "true";
 export const logPath = process.env.LOG_PATH;


### PR DESCRIPTION
… error


Fails to compile on linux when dotenv is fully imported, and as config is the only thing used, it works if only config is imported and used.